### PR TITLE
docs(changelog): add initial changelog for v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),  
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+## [1.0.0] - 2025-09-23
+### Added
+- Initial release of **Koye Preloader** WordPress plugin.
+- Customizable preloader animations, logo upload, tagline text, and page display rules.
+- Live admin preview for settings.
+- Documentation (`README.md`) with installation and usage instructions.
+- GPL-2.0-or-later LICENSE file aligned with WordPress standards.
+- `.gitignore` to exclude system junk, IDE configs, and WordPress cache files.


### PR DESCRIPTION
### Summary
- Added `CHANGELOG.md` following Keep a Changelog format.
- Documented initial release `v1.0.0` with features, documentation, license, and repo hygiene updates.

### Why This Change
A changelog provides transparency on project evolution.   This prepares the plugin for professional release cycles and makes it easier for users and maintainers to track changes.

### Notes
- Sets the baseline for future releases.  
- Matches Semantic Versioning and open-source best practices.